### PR TITLE
Remove lodash from Heapsort

### DIFF
--- a/lib/heapsort.js
+++ b/lib/heapsort.js
@@ -1,5 +1,3 @@
-const _ = require('lodash');
-
 function heapify(tree, currentRootIndex, length, comparator) {
     const leftChildIndex = 2 * currentRootIndex + 1;
     const rightChildIndex = 2 * currentRootIndex + 2;
@@ -8,8 +6,8 @@ function heapify(tree, currentRootIndex, length, comparator) {
     const leftChildNode = leftChildIndex < length ? tree[leftChildIndex] : undefined;
     const rightChildNode = rightChildIndex < length ? tree[rightChildIndex] : undefined;
 
-    const isLeftNodeLarger = !_.isUndefined(leftChildNode) && comparator(rootNode, leftChildNode) < 0;
-    const isRightNodeLarger = !_.isUndefined(rightChildNode) && comparator(rootNode, rightChildNode) < 0;
+    const isLeftNodeLarger = leftChildNode !== undefined && comparator(rootNode, leftChildNode) < 0;
+    const isRightNodeLarger = rightChildNode !== undefined && comparator(rootNode, rightChildNode) < 0;
     const isAnyLarger = isLeftNodeLarger || isRightNodeLarger;
 
     if (isAnyLarger) {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,7 @@
   "scripts": {
     "test": "istanbul cover --include-all-sources --root ./lib/ jasmine.js"
   },
-  "dependencies": {
-    "lodash": "4.17.10"
-  },
+  "dependencies": {},
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Neatoro/node-sorter.git"


### PR DESCRIPTION
Hi and congratulation on your first npm package. 

I noticed that heapsort was requiring lodash so I switched _.isUndefined out for what loadash under the hood.

All tests are passing.

Have I nice day, Hedinn